### PR TITLE
Add coverage check workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,7 +2,7 @@ name: Coverage
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   test:
@@ -22,16 +22,16 @@ jobs:
         id: coverage
         run: |
           python <<'PY'
-import re, pathlib, os
-xml = pathlib.Path('build/reports/jacoco/test/jacocoTestReport.xml').read_text()
-nums = re.findall(r'missed="(\d+)" covered="(\d+)"', xml)
-missed = sum(int(m) for m,_ in nums)
-covered = sum(int(c) for _,c in nums)
-coverage = 100 * covered / (missed + covered) if missed + covered > 0 else 0
-print(f"Coverage: {coverage:.2f}%")
-with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
-    fh.write(f'coverage={coverage:.2f}\n')
-PY
+          import re, pathlib, os
+          xml = pathlib.Path('build/reports/jacoco/test/jacocoTestReport.xml').read_text()
+          nums = re.findall(r'missed="(\d+)" covered="(\d+)"', xml)
+          missed = sum(int(m) for m,_ in nums)
+          covered = sum(int(c) for _,c in nums)
+          coverage = 100 * covered / (missed + covered) if missed + covered > 0 else 0
+          print(f"Coverage: {coverage:.2f}%")
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+              fh.write(f'coverage={coverage:.2f}\n')
+          PY
       - name: Comment PR
         uses: peter-evans/create-or-update-comment@v4
         with:
@@ -44,10 +44,10 @@ PY
           cov=${{ steps.coverage.outputs.coverage }}
           echo "Coverage $cov%"
           python - <<EOF
-import sys, os
-cov=float(os.environ.get('COV', '0'))
-if cov < 80:
-    sys.exit(1)
-EOF
+          import sys, os
+          cov=float(os.environ.get('COV', '0'))
+          if cov < 80:
+              sys.exit(1)
+          EOF
         env:
           COV: ${{ steps.coverage.outputs.coverage }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
@@ -18,6 +20,8 @@ jobs:
         uses: gradle/gradle-build-action@v3
         with:
           arguments: test jacocoTestReport
+      - name: Install diff-cover
+        run: pip install diff-cover
       - name: Calculate coverage
         id: coverage
         run: |
@@ -32,17 +36,30 @@ jobs:
           with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
               fh.write(f'coverage={coverage:.2f}\n')
           PY
+      - name: Calculate PR coverage
+        id: pr_coverage
+        run: |
+          diff-cover build/reports/jacoco/test/jacocoTestReport.xml --compare-branch ${{ github.event.pull_request.base.sha }} --fail-under=0 --json-report diffcov.json
+          python <<'PY'
+          import json, os
+          data = json.load(open('diffcov.json'))
+          cov = data.get('total_percent_covered', 0)
+          print(f"PR coverage: {cov:.2f}%")
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+              fh.write(f'coverage={cov:.2f}\n')
+          PY
       - name: Comment PR
         uses: peter-evans/create-or-update-comment@v4
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            Test coverage: **${{ steps.coverage.outputs.coverage }}%**
-            (minimum 80% required)
+            Total coverage: **${{ steps.coverage.outputs.coverage }}%**
+            Coverage on new code: **${{ steps.pr_coverage.outputs.coverage }}%**
+            (minimum 80% required on new code)
       - name: Fail if coverage below threshold
         run: |
-          cov=${{ steps.coverage.outputs.coverage }}
-          echo "Coverage $cov%"
+          cov=${{ steps.pr_coverage.outputs.coverage }}
+          echo "PR coverage $cov%"
           python - <<EOF
           import sys, os
           cov=float(os.environ.get('COV', '0'))
@@ -50,4 +67,4 @@ jobs:
               sys.exit(1)
           EOF
         env:
-          COV: ${{ steps.coverage.outputs.coverage }}
+          COV: ${{ steps.pr_coverage.outputs.coverage }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,53 @@
+name: Coverage
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@v3
+        with:
+          arguments: test jacocoTestReport
+      - name: Calculate coverage
+        id: coverage
+        run: |
+          python <<'PY'
+import re, pathlib, os
+xml = pathlib.Path('build/reports/jacoco/test/jacocoTestReport.xml').read_text()
+nums = re.findall(r'missed="(\d+)" covered="(\d+)"', xml)
+missed = sum(int(m) for m,_ in nums)
+covered = sum(int(c) for _,c in nums)
+coverage = 100 * covered / (missed + covered) if missed + covered > 0 else 0
+print(f"Coverage: {coverage:.2f}%")
+with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+    fh.write(f'coverage={coverage:.2f}\n')
+PY
+      - name: Comment PR
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            Test coverage: **${{ steps.coverage.outputs.coverage }}%**
+            (minimum 80% required)
+      - name: Fail if coverage below threshold
+        run: |
+          cov=${{ steps.coverage.outputs.coverage }}
+          echo "Coverage $cov%"
+          python - <<EOF
+import sys, os
+cov=float(os.environ.get('COV', '0'))
+if cov < 80:
+    sys.exit(1)
+EOF
+        env:
+          COV: ${{ steps.coverage.outputs.coverage }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     id("io.spring.dependency-management") version "1.1.4"
     kotlin("jvm") version "1.9.22"
     kotlin("plugin.spring") version "1.9.22"
+    jacoco
 }
 
 group = "ua.mikhalov"
@@ -53,3 +54,26 @@ tasks.withType<KotlinCompile> {
 tasks.withType<Test> {
     useJUnitPlatform()
 }
+
+jacoco {
+    toolVersion = "0.8.11"
+}
+
+tasks.jacocoTestReport {
+    dependsOn(tasks.test)
+    reports {
+        xml.required.set(true)
+        html.required.set(true)
+    }
+}
+
+tasks.jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            limit {
+                minimum = "0.8".toBigDecimal()
+            }
+        }
+    }
+}
+

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,6 +53,11 @@ tasks.withType<KotlinCompile> {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+    environment("TELEGRAM_API_KEY", "dummy")
+    environment("MONGO_USER", "user")
+    environment("MONGO_PASSWORD", "password")
+    environment("SPRING_DATA_MONGODB_URI", "mongodb://localhost")
+    environment("SPRING_DATA_MONGODB_DATABASE", "test")
 }
 
 jacoco {

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,3 @@
+spring.data.mongodb.uri=mongodb://localhost
+spring.data.mongodb.database=test
+telegram.api.key=dummy

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,3 +1,0 @@
-spring.data.mongodb.uri=mongodb://localhost
-spring.data.mongodb.database=test
-telegram.api.key=dummy


### PR DESCRIPTION
## Summary
- add JaCoCo plugin and reporting tasks
- add GitHub Action that reports coverage in PRs and fails below 80%

## Testing
- `./gradlew test jacocoTestReport`


------
https://chatgpt.com/codex/tasks/task_e_68416439398c832398e65de924da4bcf