### PR TITLE
Add extensive unit tests

### DIFF
--- a/src/test/kotlin/ua/mikhalov/notibot/config/GlobalExceptionHandlerTest.kt
+++ b/src/test/kotlin/ua/mikhalov/notibot/config/GlobalExceptionHandlerTest.kt
@@ -1,0 +1,19 @@
+package ua.mikhalov.notibot.config
+
+import com.elbekd.bot.Bot
+import com.elbekd.bot.model.ChatId
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+class GlobalExceptionHandlerTest {
+    private val bot = mockk<Bot>(relaxed = true)
+    private val handler = GlobalExceptionHandler(bot)
+
+    @Test
+    fun `handleException sends message`() = runTest {
+        handler.handleException(RuntimeException("err"), ChatId.StringId("1"))
+        coVerify { bot.sendMessage(any(), any()) }
+    }
+}

--- a/src/test/kotlin/ua/mikhalov/notibot/extentions/ExtentionsTest.kt
+++ b/src/test/kotlin/ua/mikhalov/notibot/extentions/ExtentionsTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 import java.time.LocalTime
+import java.time.LocalDateTime
 
 class ExtentionsTest {
     @Test
@@ -41,5 +42,21 @@ class ExtentionsTest {
         val callback = CallbackQuery(id = "1", from = mockk(), chatInstance = "", data = null, message = msg)
         val id = callback.getChatId()
         assertEquals("123", id.toString())
+    }
+
+    @Test
+    fun `formatToUkrainian for LocalDateTime`() {
+        val dateTime = LocalDateTime.of(2024, 2, 5, 14, 30)
+        val formatted = dateTime.formatToUkrainian()
+        assertTrue(formatted.contains("05"))
+        assertTrue(formatted.contains("2024"))
+        assertTrue(formatted.contains("14:30"))
+    }
+
+    @Test
+    fun `formatForCalendar returns month and year`() {
+        val date = LocalDate.of(2024, 2, 10)
+        val formatted = date.formatForCalendar()
+        assertEquals("Лютий 2024", formatted)
     }
 }

--- a/src/test/kotlin/ua/mikhalov/notibot/extentions/ExtentionsTest.kt
+++ b/src/test/kotlin/ua/mikhalov/notibot/extentions/ExtentionsTest.kt
@@ -1,0 +1,45 @@
+package ua.mikhalov.notibot.extentions
+
+import com.elbekd.bot.types.CallbackQuery
+import com.elbekd.bot.types.Message
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.LocalTime
+
+class ExtentionsTest {
+    @Test
+    fun `formatToUkrainian for LocalDate`() {
+        val date = LocalDate.of(2024, 1, 5)
+        val formatted = date.formatToUkrainian()
+        // Expect formatted string to contain day and year in Ukrainian locale
+        assertTrue(formatted.contains("05"))
+        assertTrue(formatted.contains("2024"))
+    }
+
+    @Test
+    fun `toLocalTime parses`() {
+        val time = "8 05".toLocalTime()
+        assertEquals(LocalTime.of(8,5), time)
+    }
+
+    @Test
+    fun `getChatId from Message`() {
+        val msg = mockk<Message>()
+        every { msg.chat.id } returns 123L
+        val id = msg.getChatId()
+        assertEquals("123", id.toString())
+    }
+
+    @Test
+    fun `getChatId from CallbackQuery`() {
+        val msg = mockk<Message>()
+        every { msg.chat.id } returns 123L
+        val callback = CallbackQuery(id = "1", from = mockk(), chatInstance = "", data = null, message = msg)
+        val id = callback.getChatId()
+        assertEquals("123", id.toString())
+    }
+}

--- a/src/test/kotlin/ua/mikhalov/notibot/model/NotiTest.kt
+++ b/src/test/kotlin/ua/mikhalov/notibot/model/NotiTest.kt
@@ -1,0 +1,45 @@
+package ua.mikhalov.notibot.model
+
+import org.bson.types.ObjectId
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+class NotiTest {
+    @Test
+    fun `setDate initializes date when null`() {
+        val noti = Noti(ObjectId.get(), "1", NotiState.AWAITING_DATE_SELECTION)
+        val date = LocalDate.of(2024, 5, 20)
+        noti.setDate(date)
+        assertEquals(LocalDateTime.of(date, LocalTime.MIN), noti.notificationDateTime)
+    }
+
+    @Test
+    fun `setDate preserves existing time`() {
+        val noti = Noti(ObjectId.get(), "1", NotiState.AWAITING_DATE_SELECTION,
+            notificationDateTime = LocalDateTime.of(2024, 1, 1, 10, 30))
+        val date = LocalDate.of(2024, 6, 15)
+        noti.setDate(date)
+        assertEquals(LocalDateTime.of(date, LocalTime.of(10, 30)), noti.notificationDateTime)
+    }
+
+    @Test
+    fun `setTime initializes time when null`() {
+        val noti = Noti(ObjectId.get(), "1", NotiState.AWAITING_TIME_INPUT)
+        val time = LocalTime.of(8, 15)
+        noti.setTime(time)
+        assertEquals(LocalDateTime.of(LocalDate.now(), time), noti.notificationDateTime)
+    }
+
+    @Test
+    fun `setTime preserves existing date`() {
+        val noti = Noti(ObjectId.get(), "1", NotiState.AWAITING_TIME_INPUT,
+            notificationDateTime = LocalDateTime.of(2024, 7, 30, 9, 0))
+        val time = LocalTime.of(22, 5)
+        noti.setTime(time)
+        assertEquals(LocalDateTime.of(2024, 7, 30, 22, 5), noti.notificationDateTime)
+    }
+}
+

--- a/src/test/kotlin/ua/mikhalov/notibot/service/BotServiceTest.kt
+++ b/src/test/kotlin/ua/mikhalov/notibot/service/BotServiceTest.kt
@@ -1,0 +1,87 @@
+package ua.mikhalov.notibot.service
+
+import com.elbekd.bot.Bot
+import com.elbekd.bot.model.ChatId
+import com.elbekd.bot.types.BotCommand
+import com.elbekd.bot.types.BotCommandScope
+import com.elbekd.bot.types.Message
+import io.mockk.*
+import kotlinx.coroutines.test.runTest
+import kotlin.reflect.full.callSuspend
+import kotlin.reflect.full.declaredFunctions
+import kotlin.reflect.jvm.isAccessible
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import ua.mikhalov.notibot.config.GlobalExceptionHandler
+import ua.mikhalov.notibot.extentions.getChatId
+import ua.mikhalov.notibot.model.User
+import ua.mikhalov.notibot.model.session.Session
+import ua.mikhalov.notibot.model.session.State
+
+class BotServiceTest {
+    private val notiInputService = mockk<NotiInputService>()
+    private val userService = mockk<UserService>()
+    private val bot = mockk<Bot>(relaxed = true)
+    private val exceptionHandler = mockk<GlobalExceptionHandler>(relaxed = true)
+    private lateinit var service: BotService
+
+    @BeforeEach
+    fun init() {
+        service = BotService(notiInputService, userService, bot, exceptionHandler)
+    }
+
+    @Test
+    fun `onStart saves user`() = runTest {
+        mockkStatic("ua.mikhalov.notibot.extentions.ExtentionsKt")
+        val msg = mockk<Message>()
+        every { msg.chat.id } returns 1L
+        every { msg.getChatId() } returns ChatId.IntegerId(1)
+        val method = BotService::class.declaredFunctions.first { it.name == "onStart" }
+        method.isAccessible = true
+        val lambda = method.call(service) as suspend (Pair<Message, String?>) -> Unit
+
+        coEvery { userService.save(any()) } returns User("1", Session(State.MAIN_MENU))
+
+        lambda(Pair(msg, null))
+
+        coVerify { bot.sendMessage(any(), any(), parseMode = any(), replyMarkup = any()) }
+        coVerify { userService.save(any()) }
+        unmockkStatic("ua.mikhalov.notibot.extentions.ExtentionsKt")
+    }
+
+    @Test
+    fun `onMessage routes to create`() = runTest {
+        mockkStatic("ua.mikhalov.notibot.extentions.ExtentionsKt")
+        val msg = mockk<Message>()
+        every { msg.getChatId() } returns ChatId.IntegerId(1)
+        every { msg.text } returns "Додати ноті"
+        val user = User("1", Session(State.MAIN_MENU))
+        coEvery { userService.findById(any()) } returns user
+        coJustRun { notiInputService.onCreate(any()) }
+
+        val method = BotService::class.declaredFunctions.first { it.name == "onMessage" }
+        method.isAccessible = true
+        val lambda = method.call(service) as suspend (Message) -> Unit
+
+        lambda(msg)
+
+        coVerify { notiInputService.onCreate(any()) }
+        unmockkStatic("ua.mikhalov.notibot.extentions.ExtentionsKt")
+    }
+
+    @Test
+    fun `onMessage handles exception`() = runTest {
+        mockkStatic("ua.mikhalov.notibot.extentions.ExtentionsKt")
+        val msg = mockk<Message>()
+        every { msg.getChatId() } returns ChatId.IntegerId(1)
+        coEvery { userService.findById(any()) } throws RuntimeException()
+        val method = BotService::class.declaredFunctions.first { it.name == "onMessage" }
+        method.isAccessible = true
+        val lambda = method.call(service) as suspend (Message) -> Unit
+
+        lambda(msg)
+
+        coVerify { exceptionHandler.handleException(any(), any()) }
+        unmockkStatic("ua.mikhalov.notibot.extentions.ExtentionsKt")
+    }
+}

--- a/src/test/kotlin/ua/mikhalov/notibot/service/NotiServiceTest.kt
+++ b/src/test/kotlin/ua/mikhalov/notibot/service/NotiServiceTest.kt
@@ -1,0 +1,36 @@
+package ua.mikhalov.notibot.service
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.bson.types.ObjectId
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import ua.mikhalov.notibot.model.Noti
+import ua.mikhalov.notibot.model.NotiState
+import ua.mikhalov.notibot.repository.NotiRepository
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+class NotiServiceTest {
+    private val repository = mockk<NotiRepository>()
+    private val service = NotiService(repository)
+
+    @Test
+    fun `updateNoti updates fields and saves`() = runTest {
+        val noti = Noti(ObjectId.get(), "1", NotiState.AWAITING_DATE_SELECTION)
+        val date = LocalDate.of(2024, 6, 15)
+        val time = LocalTime.of(9, 30)
+        val reminder = "text"
+        coEvery { repository.save(any()) } answers { firstArg() }
+
+        val updated = service.updateNoti(noti, NotiState.COMPLETED, date, time, reminder)
+
+        assertEquals(NotiState.COMPLETED, updated.notiState)
+        assertEquals(LocalDateTime.of(date, time), updated.notificationDateTime)
+        assertEquals(reminder, updated.reminderText)
+        coVerify { repository.save(noti) }
+    }
+}

--- a/src/test/kotlin/ua/mikhalov/notibot/service/ReminderServiceTest.kt
+++ b/src/test/kotlin/ua/mikhalov/notibot/service/ReminderServiceTest.kt
@@ -1,0 +1,51 @@
+package ua.mikhalov.notibot.service
+
+import com.elbekd.bot.Bot
+import com.elbekd.bot.model.ChatId
+import io.mockk.*
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.bson.types.ObjectId
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import ua.mikhalov.notibot.model.Noti
+import ua.mikhalov.notibot.model.NotiState
+import java.time.LocalDateTime
+
+class ReminderServiceTest {
+    private val notiService = mockk<NotiService>()
+    private val bot = mockk<Bot>()
+    private val service = ReminderService(notiService, bot)
+
+    @Test
+    fun `sendReminders sends notifications`() = runTest {
+        val noti = Noti(ObjectId.get(), "1", NotiState.COMPLETED, LocalDateTime.now(), "text")
+        coEvery { notiService.findNotificationsToSend(any()) } returns flowOf(noti)
+        val slot = slot<Flow<Noti>>()
+        coEvery { bot.sendMessage(any(), any()) } returns mockk()
+        coEvery { notiService.updateAll(capture(slot)) } answers { slot.captured }
+
+        service.sendReminders()
+
+        val updated = slot.captured.toList()
+        assertEquals(1, updated.size)
+        assertEquals(NotiState.SENT, updated[0].notiState)
+        coVerify { bot.sendMessage(any(), any()) }
+    }
+
+    @Test
+    fun `failed sends are skipped`() = runTest {
+        val noti = Noti(ObjectId.get(), "1", NotiState.COMPLETED, LocalDateTime.now(), "text")
+        coEvery { notiService.findNotificationsToSend(any()) } returns flowOf(noti)
+        val slot = slot<Flow<Noti>>()
+        coEvery { bot.sendMessage(any(), any()) } throws RuntimeException()
+        coEvery { notiService.updateAll(capture(slot)) } answers { slot.captured }
+
+        service.sendReminders()
+
+        val updated = slot.captured.toList()
+        assertEquals(0, updated.size)
+    }
+}

--- a/src/test/kotlin/ua/mikhalov/notibot/service/UserServiceTest.kt
+++ b/src/test/kotlin/ua/mikhalov/notibot/service/UserServiceTest.kt
@@ -1,0 +1,41 @@
+package ua.mikhalov.notibot.service
+
+import com.elbekd.bot.model.ChatId
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertThrows
+import kotlinx.coroutines.runBlocking
+import ua.mikhalov.notibot.model.User
+import ua.mikhalov.notibot.model.session.Session
+import ua.mikhalov.notibot.model.session.State
+import ua.mikhalov.notibot.repository.UserRepository
+
+class UserServiceTest {
+    private val repository = mockk<UserRepository>()
+    private val service = UserService(repository)
+
+    @Test
+    fun `updateSession updates user`() = runTest {
+        val chatId = ChatId.StringId("1")
+        val user = User("1", Session(State.MAIN_MENU))
+        coEvery { repository.findById("1") } returns user
+        coEvery { repository.save(any()) } returnsArgument 0
+
+        val result = service.updateSession(chatId, Session(State.NOTI_INPUT))
+
+        assertEquals(State.NOTI_INPUT, result.session.state)
+        coVerify { repository.save(user) }
+    }
+
+    @Test
+    fun `findById throws when missing`() = runTest {
+        coEvery { repository.findById("2") } returns null
+        assertThrows(IllegalArgumentException::class.java) {
+            runBlocking { service.findById(ChatId.StringId("2")) }
+        }
+    }
+}

--- a/src/test/kotlin/ua/mikhalov/notibot/util/KeyboardsTest.kt
+++ b/src/test/kotlin/ua/mikhalov/notibot/util/KeyboardsTest.kt
@@ -1,0 +1,23 @@
+package ua.mikhalov.notibot.util
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class KeyboardsTest {
+    @Test
+    fun `calendar for current month contains only next button`() {
+        val date = LocalDate.now().withDayOfMonth(LocalDate.now().lengthOfMonth() - 2)
+        val markup = Keyboards.Calendar.create(date)
+        val lastRow = markup.inlineKeyboard.last()
+        assertEquals(1, lastRow.size)
+    }
+
+    @Test
+    fun `calendar for non current month has prev and next buttons`() {
+        val date = LocalDate.now().minusMonths(1).withDayOfMonth(15)
+        val markup = Keyboards.Calendar.create(date)
+        val lastRow = markup.inlineKeyboard.last()
+        assertEquals(2, lastRow.size)
+    }
+}

--- a/src/test/kotlin/ua/mikhalov/notibot/util/KeyboardsTest.kt
+++ b/src/test/kotlin/ua/mikhalov/notibot/util/KeyboardsTest.kt
@@ -20,4 +20,12 @@ class KeyboardsTest {
         val lastRow = markup.inlineKeyboard.last()
         assertEquals(2, lastRow.size)
     }
+    @Test
+    fun `calendar rows contain up to seven days`() {
+        val date = LocalDate.of(2024, 1, 1)
+        val markup = Keyboards.Calendar.create(date)
+        markup.inlineKeyboard.dropLast(1).forEach { row ->
+            assert(row.size <= 7)
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add tests for Noti date/time utilities
- add tests for Keyboards calendar layout
- add tests for extension helpers
- add tests for NotiService logic
- add tests for ReminderService flows

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6841617e460883239751e2f31e5b5fe5